### PR TITLE
Allow customizing UIBlurEffect.Style

### DIFF
--- a/Examples/HUDExample/HUDExample/ViewController.swift
+++ b/Examples/HUDExample/HUDExample/ViewController.swift
@@ -25,10 +25,12 @@ final class ViewController: UIViewController {
 
     @objc
     private func showHUD() {
+        let style: [UIBlurEffect.Style] = [.dark, .systemChromeMaterial, .systemMaterial, .systemMaterialLight, .systemMaterialDark]
         let hud = HUD(
             image: UIImage(systemName: "heart"),
             title: "Loved",
-            message: "This is a beautiful HUD."
+            message: "This is a beautiful HUD.",
+            style: style.randomElement()
         )
         view.window?.show(hud)
     }

--- a/Examples/HUDExample/HUDExample/ViewController.swift
+++ b/Examples/HUDExample/HUDExample/ViewController.swift
@@ -30,7 +30,7 @@ final class ViewController: UIViewController {
             image: UIImage(systemName: "heart"),
             title: "Loved",
             message: "This is a beautiful HUD.",
-            style: style.randomElement()
+            blurEffectStyle: style.randomElement()
         )
         view.window?.show(hud)
     }

--- a/Sources/HUD/HUD/ActivityIndicatorHUD.swift
+++ b/Sources/HUD/HUD/ActivityIndicatorHUD.swift
@@ -7,8 +7,11 @@ public final class ActivityIndicatorHUD {
 
     weak var view: UIView?
 
-    public init(title: String? = nil, message: String? = nil) {
+    public var style: UIBlurEffect.Style?
+
+    public init(title: String? = nil, message: String? = nil, style: UIBlurEffect.Style? = nil) {
         self.title = title
         self.message = message
+        self.style = style
     }
 }

--- a/Sources/HUD/HUD/ActivityIndicatorHUD.swift
+++ b/Sources/HUD/HUD/ActivityIndicatorHUD.swift
@@ -7,11 +7,11 @@ public final class ActivityIndicatorHUD {
 
     weak var view: UIView?
 
-    public var style: UIBlurEffect.Style?
+    public var blurEffectStyle: UIBlurEffect.Style?
 
-    public init(title: String? = nil, message: String? = nil, style: UIBlurEffect.Style? = nil) {
+    public init(title: String? = nil, message: String? = nil, blurEffectStyle: UIBlurEffect.Style? = nil) {
         self.title = title
         self.message = message
-        self.style = style
+        self.blurEffectStyle = blurEffectStyle
     }
 }

--- a/Sources/HUD/HUD/HUD.swift
+++ b/Sources/HUD/HUD/HUD.swift
@@ -9,9 +9,12 @@ public final class HUD {
 
     weak var view: UIView?
 
-    public init(image: UIImage? = nil, title: String? = nil, message: String? = nil) {
+    public var style: UIBlurEffect.Style?
+
+    public init(image: UIImage? = nil, title: String? = nil, message: String? = nil, style: UIBlurEffect.Style? = nil) {
         self.image = image
         self.title = title
         self.message = message
+        self.style = style
     }
 }

--- a/Sources/HUD/HUD/HUD.swift
+++ b/Sources/HUD/HUD/HUD.swift
@@ -9,12 +9,12 @@ public final class HUD {
 
     weak var view: UIView?
 
-    public var style: UIBlurEffect.Style?
+    public var blurEffectStyle: UIBlurEffect.Style?
 
-    public init(image: UIImage? = nil, title: String? = nil, message: String? = nil, style: UIBlurEffect.Style? = nil) {
+    public init(image: UIImage? = nil, title: String? = nil, message: String? = nil, blurEffectStyle: UIBlurEffect.Style? = nil) {
         self.image = image
         self.title = title
         self.message = message
-        self.style = style
+        self.blurEffectStyle = blurEffectStyle
     }
 }

--- a/Sources/HUD/HUD/HUDProtocol.swift
+++ b/Sources/HUD/HUD/HUDProtocol.swift
@@ -7,7 +7,7 @@ protocol HUDProtocol: AnyObject {
 
     var view: UIView? { get set }
 
-    var style: UIBlurEffect.Style? { get set }
+    var blurEffectStyle: UIBlurEffect.Style? { get set }
 
     func makeHUDView() -> UIView
 }

--- a/Sources/HUD/HUD/HUDProtocol.swift
+++ b/Sources/HUD/HUD/HUDProtocol.swift
@@ -7,6 +7,8 @@ protocol HUDProtocol: AnyObject {
 
     var view: UIView? { get set }
 
+    var style: UIBlurEffect.Style? { get set }
+
     func makeHUDView() -> UIView
 }
 

--- a/Sources/HUD/Views/_HUDView.swift
+++ b/Sources/HUD/Views/_HUDView.swift
@@ -43,7 +43,7 @@ class _HUDView: View {
 
     public init(hud: HUDProtocol) {
         assert(hud.view == nil)
-        blurEffect = UIBlurEffect(style: hud.style ?? .systemThinMaterial)
+        blurEffect = UIBlurEffect(style: hud.blurEffectStyle ?? .systemThinMaterial)
 
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/HUD/Views/_HUDView.swift
+++ b/Sources/HUD/Views/_HUDView.swift
@@ -14,7 +14,7 @@ class View: UIView {
 // MARK: -
 
 class _HUDView: View {
-    private lazy var blurEffect = UIBlurEffect(style: .systemThinMaterial)
+    private let blurEffect: UIBlurEffect
 
     private lazy var blurEffectView: UIVisualEffectView = {
         let visualEffectView = UIVisualEffectView(effect: blurEffect)
@@ -43,8 +43,11 @@ class _HUDView: View {
 
     public init(hud: HUDProtocol) {
         assert(hud.view == nil)
+        blurEffect = UIBlurEffect(style: hud.style ?? .systemThinMaterial)
+
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
+
         setUpSubviews()
         setUpConstraints()
         setUpStackViewArrangedSubviews(for: hud)


### PR DESCRIPTION
The host App should be able to customize the UIBlurEffect.Style, because it is up to the App to decide the background. The default .systemThinMaterial is sometimes not good for some scenarios.

## Before Change

If I use .systemThinMaterial, it is hardly to tell the difference from the background.

<img width="300" src="https://user-images.githubusercontent.com/4256824/116767743-b9777f80-aa64-11eb-8636-4b0d4c06f5c2.png" />

## After Change

I use .systemChromeMaterial to display a clearer border.

<img width="300" src="https://user-images.githubusercontent.com/4256824/116767812-20953400-aa65-11eb-8f20-e9eb695aff88.png" />